### PR TITLE
Move from Bintray to Sonatype

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Assemble
         if: ${{ runner.os == 'Linux' }}
         env:
-          OSSRH_USERNAME: ${{ OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ OSSRH_PASSWORD }}
-          OSSRH_SIGNING_KEY_ID: ${{ OSSRH_SIGNING_KEY_ID }}
-          OSSRH_SIGNING_KEY: ${{ OSSRH_SIGNING_KEY }}
-          OSSRH_SIGNING_PASSWORD: ${{ OSSRH_SIGNING_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_SIGNING_KEY_ID: ${{ secrets.OSSRH_SIGNING_KEY_ID }}
+          OSSRH_SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
+          OSSRH_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
         run: ./gradlew assemble --info --stacktrace -Plogtests
 
       - name: Stop Gradle Daemon

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,6 +44,12 @@ jobs:
 
       - name: Assemble
         if: ${{ runner.os == 'Linux' }}
+        env:
+          OSSRH_USERNAME: ${{ OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ OSSRH_PASSWORD }}
+          OSSRH_SIGNING_KEY_ID: ${{ OSSRH_SIGNING_KEY_ID }}
+          OSSRH_SIGNING_KEY: ${{ OSSRH_SIGNING_KEY }}
+          OSSRH_SIGNING_PASSWORD: ${{ OSSRH_SIGNING_PASSWORD }}
         run: ./gradlew assemble --info --stacktrace -Plogtests
 
       - name: Stop Gradle Daemon

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,17 +31,17 @@ jobs:
       - name: Build Artifacts
         run: ./gradlew assemble --info --stacktrace
         env:
-          OSSRH_USERNAME: ${{ OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ OSSRH_PASSWORD }}
-          OSSRH_SIGNING_KEY_ID: ${{ OSSRH_SIGNING_KEY_ID }}
-          OSSRH_SIGNING_KEY: ${{ OSSRH_SIGNING_KEY }}
-          OSSRH_SIGNING_PASSWORD: ${{ OSSRH_SIGNING_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_SIGNING_KEY_ID: ${{ secrets.OSSRH_SIGNING_KEY_ID }}
+          OSSRH_SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
+          OSSRH_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
 
       - name: Publish
         run: ./gradlew publish --info --stacktrace
         env:
-          OSSRH_USERNAME: ${{ OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ OSSRH_PASSWORD }}
-          OSSRH_SIGNING_KEY_ID: ${{ OSSRH_SIGNING_KEY_ID }}
-          OSSRH_SIGNING_KEY: ${{ OSSRH_SIGNING_KEY }}
-          OSSRH_SIGNING_PASSWORD: ${{ OSSRH_SIGNING_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_SIGNING_KEY_ID: ${{ secrets.OSSRH_SIGNING_KEY_ID }}
+          OSSRH_SIGNING_KEY: ${{ secrets.OSSRH_SIGNING_KEY }}
+          OSSRH_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,9 +30,18 @@ jobs:
 
       - name: Build Artifacts
         run: ./gradlew assemble --info --stacktrace
-
-      - name: Upload
-        run: ./gradlew bintrayUpload --info --stacktrace
         env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          OSSRH_USERNAME: ${{ OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ OSSRH_PASSWORD }}
+          OSSRH_SIGNING_KEY_ID: ${{ OSSRH_SIGNING_KEY_ID }}
+          OSSRH_SIGNING_KEY: ${{ OSSRH_SIGNING_KEY }}
+          OSSRH_SIGNING_PASSWORD: ${{ OSSRH_SIGNING_PASSWORD }}
+
+      - name: Publish
+        run: ./gradlew publish --info --stacktrace
+        env:
+          OSSRH_USERNAME: ${{ OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ OSSRH_PASSWORD }}
+          OSSRH_SIGNING_KEY_ID: ${{ OSSRH_SIGNING_KEY_ID }}
+          OSSRH_SIGNING_KEY: ${{ OSSRH_SIGNING_KEY }}
+          OSSRH_SIGNING_PASSWORD: ${{ OSSRH_SIGNING_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -197,9 +197,10 @@ publishing {
 }
 
 signing {
+    val signingKeyId = findProperty("OSSRH_SIGNING_KEY_ID") as String?
     val signingKey = findProperty("OSSRH_SIGNING_KEY") as String?
     val signingPassword = findProperty("OSSRH_SIGNING_PASSWORD") as String?
-    useInMemoryPgpKeys(signingKey, signingPassword)
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     sign(publishing.publications[publicationName])
     sign(configurations.archives.get())
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,6 +141,12 @@ task<Jar>("sourcesJar") {
     from(sourceSets.main.get().allSource)
 }
 
+task<Jar>("javadocJar") {
+    archiveClassifier.set("javadoc")
+    archiveBaseName.set(Metadata.projectName)
+    from(tasks.named("javadoc"))
+}
+
 val publicationName = "bowler-proto-kotlin"
 
 publishing {
@@ -149,6 +155,7 @@ publishing {
             artifactId = Metadata.projectName
             from(components["java"])
             artifact(tasks["sourcesJar"])
+            artifact(tasks["javadocJar"])
             try {
                 artifact(tasks.named("shadowJar"))
             } catch (ex: UnknownTaskException) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -189,14 +189,14 @@ publishing {
             val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
             url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
             credentials {
-                if (System.getenv("OSSRH_USERNAME")?.isEmpty() == true) {
-                    println("Assuming publishing credentials are configured through project properties `OSSRH_USERNAME` and `OSSRH_PASSWORD`.")
-                    username = findProperty("OSSRH_USERNAME") as String?
-                    password = findProperty("OSSRH_PASSWORD") as String?
-                } else {
+                if (System.getenv("OSSRH_USERNAME")?.isNotEmpty() == true) {
                     println("Using environment variables `OSSRH_USERNAME` and `OSSRH_PASSWORD` for publishing credentials.")
                     username = System.getenv("OSSRH_USERNAME")
                     password = System.getenv("OSSRH_PASSWORD")
+                } else {
+                    println("Assuming publishing credentials are configured through project properties `OSSRH_USERNAME` and `OSSRH_PASSWORD`.")
+                    username = findProperty("OSSRH_USERNAME") as String?
+                    password = findProperty("OSSRH_PASSWORD") as String?
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -197,8 +197,8 @@ publishing {
 }
 
 signing {
-    val signingKey: String? by project
-    val signingPassword: String? by project
+    val signingKey = findProperty("OSSRH_SIGNING_KEY") as String?
+    val signingPassword = findProperty("OSSRH_SIGNING_PASSWORD") as String?
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications[publicationName])
     sign(configurations.archives.get())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -189,7 +189,7 @@ publishing {
             val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
             url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
             credentials {
-                if (System.getenv("OSSRH_USERNAME").isEmpty()) {
+                if (System.getenv("OSSRH_USERNAME")?.isEmpty() == true) {
                     println("Assuming publishing credentials are configured through project properties `OSSRH_USERNAME` and `OSSRH_PASSWORD`.")
                     username = findProperty("OSSRH_USERNAME") as String?
                     password = findProperty("OSSRH_PASSWORD") as String?
@@ -204,7 +204,7 @@ publishing {
 }
 
 signing {
-    if (System.getenv("OSSRH_SIGNING_KEY").isNotEmpty()) {
+    if (System.getenv("OSSRH_SIGNING_KEY")?.isNotEmpty() == true) {
         val signingKey = System.getenv("OSSRH_SIGNING_KEY")
         val signingPassword = System.getenv("OSSRH_SIGNING_PASSWORD")
         val signingKeyId = System.getenv("OSSRH_SIGNING_KEY_ID")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -197,6 +197,9 @@ publishing {
 }
 
 signing {
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications[publicationName])
     sign(configurations.archives.get())
 }

--- a/buildSrc/src/main/kotlin/Metadata.kt
+++ b/buildSrc/src/main/kotlin/Metadata.kt
@@ -20,7 +20,9 @@ object Metadata {
     const val projectName = "bowler-proto-kotlin"
     const val projectDescription = "Generated Kotlin code for the bowler-proto protobuf definitions."
     const val organization = "commonwealthrobotics"
+    const val groupId = "com.commonwealthrobotics"
     const val license = "Apache-2.0"
+    const val githubRepo = "https://github.com/CommonWealthRobotics/bowler-proto-kotlin"
 
     object Bintray {
         const val repo = "maven-artifacts"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -30,7 +30,7 @@ object Versions {
     const val protobufJava = "3.12.4"
     const val grpc = "1.34.0"
     const val grpcKotlin = "1.0.0"
-    const val javaxAnnotationAPI = "1.3.+"
+    const val javaxAnnotationAPI = "1.3.2"
 
     const val gradleWrapper = "6.6.1"
 }


### PR DESCRIPTION
### Description of the Change

This PR removes the old Bintray publishing and configures Sonatype publishing instead.

### Motivation

Bintray's JCenter is being sunset and will stop resolving artifacts on February 1st, 2022.
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

~~I still need to check I can consume my published artifacts in another project.~~ I will do this once the sync for our repo is enabled (this is our first package under the `com.commonwealthrobotics` domain). https://repo1.maven.org/maven2/com/commonwealthrobotics/bowler-proto-kotlin/0.6.9-1/

The CheckNewVersion action is expected to fail on this PR because I am not releasing a new version. I am just publishing the latest version to a new repository.

### Applicable Issues

<!-- Enter any applicable Issues here. E.g., "Closes #49." -->
